### PR TITLE
feat(web): 诊断页改用 /projects 统一列表

### DIFF
--- a/src/pages/Triage.tsx
+++ b/src/pages/Triage.tsx
@@ -7,8 +7,15 @@ export default function Triage() {
   const [url, setUrl] = React.useState('')
   const [logs, setLogs] = React.useState('')
   const { data: projects } = useQuery({
-    queryKey: ['offline-projects'],
-    queryFn: () => get<{ projects: { key: string; alias: string }[] }>('/offline/projects'),
+    queryKey: ['projects'],
+    queryFn: async () => {
+      try {
+        return await get<{ projects: { key: string; alias: string; branch?: string }[] }>('/projects')
+      } catch {
+        // 兼容旧后端：回退到 /offline/projects
+        return await get<{ projects: { key: string; alias: string; branch?: string }[] }>('/offline/projects')
+      }
+    },
   })
   const [project, setProject] = React.useState<string | undefined>(undefined)
   const triage = useMutation({


### PR DESCRIPTION
- 使用 /projects 合并离线+API 来源；失败回退 /offline/projects